### PR TITLE
Fix align() directive

### DIFF
--- a/src/hotspot/cpu/x86/globals_x86.hpp
+++ b/src/hotspot/cpu/x86/globals_x86.hpp
@@ -44,7 +44,7 @@ define_pd_global(uintx, CodeCacheSegmentSize,    64 COMPILER1_AND_COMPILER2_PRES
 // the uep and the vep doesn't get real alignment but just slops on by
 // only assured that the entry instruction meets the 5 byte size requirement.
 #if COMPILER2_OR_JVMCI
-define_pd_global(intx, CodeEntryAlignment,       32);
+define_pd_global(intx, CodeEntryAlignment,       64);
 #else
 define_pd_global(intx, CodeEntryAlignment,       16);
 #endif // COMPILER2_OR_JVMCI

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1171,7 +1171,7 @@ void MacroAssembler::addpd(XMMRegister dst, AddressLiteral src) {
 }
 
 void MacroAssembler::align(int modulus) {
-  align(modulus, offset());
+  align(modulus, (intptr_t)pc());
 }
 
 void MacroAssembler::align(int modulus, int target) {

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1171,7 +1171,7 @@ void MacroAssembler::addpd(XMMRegister dst, AddressLiteral src) {
 }
 
 void MacroAssembler::align(int modulus) {
-  align(modulus, (intptr_t)pc());
+  align(modulus, offset());
 }
 
 void MacroAssembler::align(int modulus, int target) {


### PR DESCRIPTION
Change align(x) to be relative to the current section's end rather than its size.  Issue was uncovered with a raw align(64).